### PR TITLE
Allow compilation on Ubuntu

### DIFF
--- a/Software/app/basic/stm32wlxx_it.c
+++ b/Software/app/basic/stm32wlxx_it.c
@@ -22,7 +22,7 @@
 /* USER CODE END Header */
 
 /* Includes ------------------------------------------------------------------*/
-#include "GNSE_BSP.h"
+#include "GNSE_bsp.h"
 #include "stm32wlxx_it.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */

--- a/Software/app/basic_bootloader/stm32wlxx_it.c
+++ b/Software/app/basic_bootloader/stm32wlxx_it.c
@@ -22,7 +22,7 @@
 /* USER CODE END Header */
 
 /* Includes ------------------------------------------------------------------*/
-#include "GNSE_BSP.h"
+#include "GNSE_bsp.h"
 #include "stm32wlxx_it.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */

--- a/Software/app/basic_freertos/stm32wlxx_it.c
+++ b/Software/app/basic_freertos/stm32wlxx_it.c
@@ -19,7 +19,7 @@
   ******************************************************************************
   */
 
-#include "GNSE_BSP.h"
+#include "GNSE_bsp.h"
 #include "stm32wlxx_it.h"
 
 extern TIM_HandleTypeDef htim17;

--- a/Software/cross.cmake
+++ b/Software/cross.cmake
@@ -14,6 +14,7 @@
 #-----------------------------
 # Important: TOOLCHAIN_PREFIX must be configured as it's system and user dependant
 # MAC OSX and Linux Example -> set(TOOLCHAIN_PREFIX "/Users/USER/opt/gcc-arm-none-eabi-9-2020-q2-update/")
+# Ubuntu install from 'sudo apt install gcc-arm-none-eabi' -> set(TOOLCHAIN_PREFIX "/usr")
 # Windows Example -> set(TOOLCHAIN_PREFIX "C:/Program Files (x86)/GNU Tools ARM Embedded/9 2020-q2-update/")
 # Docker Example -> set(TOOLCHAIN_PREFIX "/toolchain/gcc-arm-none-eabi-9-2020-q2-update/")
 

--- a/Software/lib/SHTC3/sensirion_hw_i2c_implementation.c
+++ b/Software/lib/SHTC3/sensirion_hw_i2c_implementation.c
@@ -31,7 +31,7 @@
 
 #include "stm32wlxx_hal.h"
 #include "sensirion_i2c.h"
-#include "GNSE_BSP.h"
+#include "GNSE_bsp.h"
 
 /**
  * Initialize all hard- and software components that are needed for the I2C


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Allows building on Ubuntu (specifically under WSL)

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Include default toolchain prefix path for `gcc-arm-none-eabi` installed in Ubuntu using apt.
- Corrected the capitalisation of the `GNSE_bsp.h` includes to match the file capitalisation - required for using `make` on Linux

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Use the line 17 TOOLCHAIN_PREFIX set for ubuntu installations where gcc-arm-none-eabi has been installed by running:

```bash
sudo apt install gcc-arm-none-eabi
```
