### PR TITLE
Set default toolchain parameters

### DIFF
--- a/Software/CMakeLists.txt
+++ b/Software/CMakeLists.txt
@@ -15,7 +15,8 @@
 cmake_minimum_required(VERSION 3.11.1)
 
 if(NOT CMAKE_TOOLCHAIN_FILE)
-    message(FATAL_ERROR "[ERRR] CMAKE_TOOLCHAIN_FILE not specified")
+    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/cross.cmake" CACHE STRING "Choose the toolchain file." FORCE)
+    message(WARNING "[WARN] CMAKE_TOOLCHAIN_FILE not specified: Using ${CMAKE_TOOLCHAIN_FILE} by default")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/Software/cross.cmake
+++ b/Software/cross.cmake
@@ -18,6 +18,8 @@
 # Windows Example -> set(TOOLCHAIN_PREFIX "C:/Program Files (x86)/GNU Tools ARM Embedded/9 2020-q2-update/")
 # Docker Example -> set(TOOLCHAIN_PREFIX "/toolchain/gcc-arm-none-eabi-9-2020-q2-update/")
 
+set(TOOLCHAIN_PREFIX "/usr" CACHE STRING "Toolchain installation directory." FORCE)
+
 if(NOT TOOLCHAIN_PREFIX)
     message(FATAL_ERROR "[ERRR] TOOLCHAIN_PREFIX not specified, please update the with compiler toolchain location")
 endif()


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Set default toolchain parameters and allow to pass `TOOLCHAIN_PREFIX` in command line.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**

- Most of the time `cross.cmake` will be used as toolcahin file.
- It's better to pass an argument than having to modify a file to make it work.
