### PR TITLE
fix/cubeide-typo

### DIFF
--- a/Software/app/basic/.cproject
+++ b/Software/app/basic/.cproject
@@ -58,7 +58,7 @@
 									<listOptionValue builtIn="false" value="../../../lib/cryptoauthlib/lib/host"/>
 									<listOptionValue builtIn="false" value="../../"/>
 									<listOptionValue builtIn="false" value="../conf"/>
-									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/include"/>
+									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/Include"/>
 									<listOptionValue builtIn="false" value="../../../target/stm32wlxx_hal_driver/Inc"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includefiles.1165198300" name="Include files (-include)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includefiles" useByScannerDiscovery="false" valueType="includeFiles"/>

--- a/Software/app/basic_bootloader/.cproject
+++ b/Software/app/basic_bootloader/.cproject
@@ -59,7 +59,7 @@
 									<listOptionValue builtIn="false" value="../../../lib/cryptoauthlib/lib/host"/>
 									<listOptionValue builtIn="false" value="../../"/>
 									<listOptionValue builtIn="false" value="../conf"/>
-									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/include"/>
+									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/Include"/>
 									<listOptionValue builtIn="false" value="../../../target/stm32wlxx_hal_driver/Inc"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includefiles.1165198300" name="Include files (-include)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.compiler.option.includefiles" useByScannerDiscovery="false" valueType="includeFiles"/>

--- a/Software/app/basic_freertos/.cproject
+++ b/Software/app/basic_freertos/.cproject
@@ -58,7 +58,7 @@
 									<listOptionValue builtIn="false" value="../../../lib/cryptoauthlib/lib/host"/>
 									<listOptionValue builtIn="false" value="../../"/>
 									<listOptionValue builtIn="false" value="../conf"/>
-									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/include"/>
+									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/Include"/>
 									<listOptionValue builtIn="false" value="../../../target/stm32wlxx_hal_driver/Inc"/>
 									<listOptionValue builtIn="false" value="../../../lib/FreeRTOS-Kernel/include"/>
 									<listOptionValue builtIn="false" value="../../../lib/FreeRTOS-Utilities"/>

--- a/Software/app/basic_lorawan/.cproject
+++ b/Software/app/basic_lorawan/.cproject
@@ -52,7 +52,7 @@
 									<listOptionValue builtIn="false" value="../../"/>
 									<listOptionValue builtIn="false" value="../conf"/>
 									<listOptionValue builtIn="false" value="../lib_dependency"/>
-									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/include"/>
+									<listOptionValue builtIn="false" value="../../../target/CMSIS/Core/Include"/>
 									<listOptionValue builtIn="false" value="../../../target/stm32wlxx_hal_driver/Inc"/>
 									<listOptionValue builtIn="false" value="../../../lib/STM32WLxx_LoRaWAN/LoRaWAN/Crypto"/>
 									<listOptionValue builtIn="false" value="../../../lib/STM32WLxx_LoRaWAN/LoRaWAN/LmHandler"/>


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

STM32CubeIDE will not build on Linux due to small capitalisation typos in the .cproject files. Closes #125.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Capitalised all instances of 'include'

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Check on your OS if the changed didn't affect your build.


