### PR TITLE
dev: Add faster CMakelists for development

### DIFF
--- a/Software/tools/cmake_dev/basic.CMakeLists.txt
+++ b/Software/tools/cmake_dev/basic.CMakeLists.txt
@@ -1,0 +1,92 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+    "${PROJECT_SOURCE_DIR}/app/basic/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_clk_timer.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_bm.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+    "${PROJECT_SOURCE_DIR}/lib/SHTC3/sensirion_common.c"
+    "${PROJECT_SOURCE_DIR}/lib/SHTC3/sensirion_hw_i2c_implementation.c"
+    "${PROJECT_SOURCE_DIR}/lib/SHTC3/SHTC3.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/MX25R16.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/mxic_hc.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/mx_test.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/nor_cmd.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/nor_ops.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/spi.c"
+    "${PROJECT_SOURCE_DIR}/lib/LIS2DH12/LIS2DH12.c"
+    "${PROJECT_SOURCE_DIR}/lib/LIS2DH12/st_hw_i2c_implementation.c"
+    "${PROJECT_SOURCE_DIR}/lib/BUZZER/BUZZER.c"
+    "${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se-hal.c"
+    "${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA/tnglora_read_helper.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_basic.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_command.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_debug.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_device.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_iface.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_basic.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_command.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_execution.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_read.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/hal/atca_hal.c"
+    )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/basic
+    ${PROJECT_SOURCE_DIR}/app/basic/conf
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_HAL
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    ${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/hal
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+    )

--- a/Software/tools/cmake_dev/basic_bootloader.CMakeLists.txt
+++ b/Software/tools/cmake_dev/basic_bootloader.CMakeLists.txt
@@ -1,0 +1,63 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+    "${PROJECT_SOURCE_DIR}/app/basic_bootloader/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+    "${PROJECT_SOURCE_DIR}/lib/MCU_FLASH/MCU_FLASH.c"
+    )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/basic_bootloader
+    ${PROJECT_SOURCE_DIR}/app/basic_bootloader/conf
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/MCU_FLASH
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+    )

--- a/Software/tools/cmake_dev/basic_freertos.CMakeLists.txt
+++ b/Software/tools/cmake_dev/basic_freertos.CMakeLists.txt
@@ -1,0 +1,76 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+    "${PROJECT_SOURCE_DIR}/app/basic_freertos/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_radio.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/list.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/tasks.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3/port.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/MemMang/heap_4.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/FreeRTOS_iot_log_task_dynamic_buffers.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/stm32wlxx_hal_timebase_tim.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/freertos_sleep.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/queue.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/timers.c"
+    "${PROJECT_SOURCE_DIR}/target/FreeRTOS_CMSIS/cmsis_os2.c"
+    )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/basic_freertos
+    ${PROJECT_SOURCE_DIR}/app/basic_freertos/conf
+    ${PROJECT_SOURCE_DIR}/app/basic_freertos/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/freertos
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/include
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/target/FreeRTOS_CMSIS
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+    )

--- a/Software/tools/cmake_dev/basic_lorawan.CMakeLists.txt
+++ b/Software/tools/cmake_dev/basic_lorawan.CMakeLists.txt
@@ -1,0 +1,127 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# LoRaWAN library
+#-------------------
+file(GLOB LORAWAN_SRC
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/cmac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/lorawan_aes.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/soft-se.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/LmHandler.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/NvmCtxMgmt.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages/LmhpCompliance.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacAdr.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacClassB.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCommands.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacConfirmQueue.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCrypto.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacParser.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacSerializer.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/Region.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionCommon.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionEU868.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionUS915.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities/utilities.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio_driver.c"
+    )
+add_library(lorawan STATIC
+    ${LORAWAN_SRC}
+    )
+target_include_directories(lorawan
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/${HAL_DIR}/Inc
+    ${PROJECT_SOURCE_DIR}/${MCU_DIR}/Include
+    ${PROJECT_SOURCE_DIR}/${CMSIS_DIR}/Core/Include
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app/basic_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/basic_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    )
+target_compile_definitions(lorawan
+    PUBLIC
+    ${MCU}
+    )
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+        "${PROJECT_SOURCE_DIR}/app/basic_lorawan/*.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_rtc.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_seq.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_systime.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_clk_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+        )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/basic_lorawan
+    ${PROJECT_SOURCE_DIR}/app/basic_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/basic_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_HAL
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    lorawan
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+)

--- a/Software/tools/cmake_dev/freefall_lorawan.CMakeLists.txt
+++ b/Software/tools/cmake_dev/freefall_lorawan.CMakeLists.txt
@@ -1,0 +1,129 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# LoRaWAN library
+#-------------------
+file(GLOB LORAWAN_SRC
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/cmac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/lorawan_aes.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/soft-se.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/LmHandler.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/NvmCtxMgmt.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages/LmhpCompliance.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacAdr.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacClassB.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCommands.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacConfirmQueue.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCrypto.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacParser.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacSerializer.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/Region.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionCommon.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionEU868.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionUS915.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities/utilities.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio_driver.c"
+    )
+add_library(lorawan STATIC
+    ${LORAWAN_SRC}
+    )
+target_include_directories(lorawan
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/${HAL_DIR}/Inc
+    ${PROJECT_SOURCE_DIR}/${MCU_DIR}/Include
+    ${PROJECT_SOURCE_DIR}/${CMSIS_DIR}/Core/Include
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app/freefall_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/freefall_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    )
+target_compile_definitions(lorawan
+    PUBLIC
+    ${MCU}
+    )
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+        "${PROJECT_SOURCE_DIR}/app/freefall_lorawan/*.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_clk_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_acc.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_rtc.c"
+        "${PROJECT_SOURCE_DIR}/lib/LIS2DH12/LIS2DH12.c"
+        "${PROJECT_SOURCE_DIR}/lib/LIS2DH12/st_hw_i2c_implementation.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_seq.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_systime.c"
+        "${PROJECT_SOURCE_DIR}/target/stm32wlxx_hal_driver/Src/stm32wlxx_hal_i2c.c"
+        "${PROJECT_SOURCE_DIR}/target/stm32wlxx_hal_driver/Src/stm32wlxx_hal_i2c_ex.c"
+        )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/app/freefall_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/freefall_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_HAL
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    lorawan
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+)

--- a/Software/tools/cmake_dev/freertos_lorawan.CMakeLists.txt
+++ b/Software/tools/cmake_dev/freertos_lorawan.CMakeLists.txt
@@ -1,0 +1,147 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# LoRaWAN library
+#-------------------
+file(GLOB LORAWAN_SRC
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/cmac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/lorawan_aes.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto/soft-se.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/LmHandler.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/NvmCtxMgmt.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages/LmhpCompliance.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacAdr.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacClassB.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCommands.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacConfirmQueue.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCrypto.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacParser.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacSerializer.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/Region.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionCommon.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionEU868.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionUS915.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities/utilities.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio_driver.c"
+    )
+add_library(lorawan STATIC
+    ${LORAWAN_SRC}
+    )
+target_include_directories(lorawan
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/${HAL_DIR}/Inc
+    ${PROJECT_SOURCE_DIR}/${MCU_DIR}/Include
+    ${PROJECT_SOURCE_DIR}/${CMSIS_DIR}/Core/Include
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/include
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/freertos
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app/freertos_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/freertos_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    )
+target_compile_definitions(lorawan
+    PUBLIC
+    ${MCU}
+    )
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+    "${PROJECT_SOURCE_DIR}/app/freertos_lorawan/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_clk_timer.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+    "${PROJECT_SOURCE_DIR}/lib/MCU_FLASH/MCU_FLASH.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/list.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/tasks.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3/port.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3/secure/secure_heap.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/MemMang/heap_4.c"
+    "${PROJECT_SOURCE_DIR}/target/FreeRTOS_CMSIS/cmsis_os2.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/FreeRTOS_iot_log_task_dynamic_buffers.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/FreeRTOS_iot_log_task.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/FreeRTOS_sleep.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/freertos_systime.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/freertos/stm32wlxx_hal_timebase_tim.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_lpm.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_timer.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_seq.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-LoRaWAN/credentials.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-LoRaWAN/freertos_lorawan.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-LoRaWAN/timer.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/queue.c"
+    "${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/timers.c"
+    )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/target/FreeRTOS_CMSIS
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/freertos_lorawan
+    ${PROJECT_SOURCE_DIR}/app/freertos_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/freertos_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/MCU_FLASH
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/freertos
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-LoRaWAN
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/include
+    ${PROJECT_SOURCE_DIR}/lib/FreeRTOS-Kernel/portable/GCC/ARM_CM3
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    lorawan
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+    )

--- a/Software/tools/cmake_dev/secure_element_lorawan.CMakeLists.txt
+++ b/Software/tools/cmake_dev/secure_element_lorawan.CMakeLists.txt
@@ -1,0 +1,147 @@
+###############################################################################
+################################### WARNING ###################################
+###############################################################################
+#
+# This CMakeLists.txt is for development purposes only.
+#
+###############################################################################
+###############################################################################
+###############################################################################
+#-------------------
+# LoRaWAN library
+#-------------------
+file(GLOB LORAWAN_SRC
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/LmHandler.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/NvmCtxMgmt.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages/LmhpCompliance.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacAdr.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMac.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacClassB.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCommands.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacConfirmQueue.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacCrypto.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacParser.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/LoRaMacSerializer.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/Region.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionCommon.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionEU868.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region/RegionUS915.c"
+    "${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se.c"
+    "${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se-hal.c"
+    "${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA/tnglora_read_helper.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_basic.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_command.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_debug.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_device.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/atca_iface.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_aes.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_basic.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_command.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_execution.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_kdf.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib/calib_read.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/crypto/atca_crypto_hw_aes_cmac.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/crypto/atca_crypto_hw_aes_cbc.c"
+    "${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/hal/atca_hal.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities/utilities.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio.c"
+    "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/radio_driver.c"
+    )
+add_library(lorawan STATIC
+    ${LORAWAN_SRC}
+    )
+target_include_directories(lorawan
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/${HAL_DIR}/Inc
+    ${PROJECT_SOURCE_DIR}/${MCU_DIR}/Include
+    ${PROJECT_SOURCE_DIR}/${CMSIS_DIR}/Core/Include
+    ${PROJECT_SOURCE_DIR}/lib/ATECC608A-TNGLORA
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/calib
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/crypto
+    ${PROJECT_SOURCE_DIR}/lib/cryptoauthlib/lib/hal
+    # ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Crypto
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/LmHandler/packages
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Mac/region
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Patterns/Basic
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy
+    ${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    )
+target_compile_definitions(lorawan
+    PUBLIC
+    ${MCU}
+    )
+#-------------------
+# Main elf
+#-------------------
+file(GLOB MAIN_SRC
+        "${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/*.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_clk_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_gpio.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_msp.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/GNSE_bsp_serial.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_rtc.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_adv_trace.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_lpm.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_mem.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/stm32_tiny_vsnprintf.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/usart_if.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_timer.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_seq.c"
+        "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/stm32_systime.c"
+        )
+set(SOURCES
+    ${MAIN_SRC}
+    ${PROJECT_SOURCE_DIR}/${STARTUP_FILE}
+    ${PROJECT_SOURCE_DIR}/${SYSTEM_FILE}
+    )
+add_executable(${PROJECT_NAME}.elf
+    ${SOURCES}
+    )
+target_include_directories(${PROJECT_NAME}.elf
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/target
+    ${PROJECT_SOURCE_DIR}/app
+    ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan
+    ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/conf
+    ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/lib_dependency
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_HAL
+    ${PROJECT_SOURCE_DIR}/lib/Utilities
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
+    )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    lorawan
+    )
+target_compile_definitions(${PROJECT_NAME}.elf
+    PUBLIC
+    ${MCU}
+    SEMIHOSTING=${SEMIHOSTING}
+    )
+    # Create output in hex and binary format
+    create_bin_output(${PROJECT_NAME})
+    create_hex_output(${PROJECT_NAME})
+    # Add additional files to the make clean
+    set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${PROJECT_NAME}.map"
+    "${PROJECT_NAME}.bin"
+    "${PROJECT_NAME}.hex"
+)


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

For faster compilation speed, a few development CMakelists.txt were added to every app. Closes #63.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Each app has a CMakeLists.devel.txt as alternative CMakeLists.txt.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Change the CMakeLists.txt and check if all apps build with Cmake and if they still function properly. Also tell if you like the idea of naming them .devel or if you have a better idea of implementing these (I don't know enough about Cmake to know if there is a cleaner solution for this).