### PR TITLE
lib,app: Defined power on times

### DIFF
--- a/Software/app/basic/main.c
+++ b/Software/app/basic/main.c
@@ -60,9 +60,8 @@ int main(void)
   APP_PPRINTF("\r\n 1) Enabling LOAD_SWITCH_SENSORS \r\n");
   GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
   GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
-  HAL_Delay(100);
+  HAL_Delay(LOAD_SWITCH_SENSORS_DELAY_MS);
   GNSE_BSP_Sensor_I2C1_Init();
-  HAL_Delay(100);
   APP_PPRINTF("\r\n 2) Attempting to read secure element serial number \r\n");
   secure_element_read_info();
 
@@ -75,7 +74,7 @@ int main(void)
   APP_PPRINTF("\r\n 1) Enabling LOAD_SWITCH_FLASH \r\n");
   GNSE_BSP_LS_Init(LOAD_SWITCH_FLASH);
   GNSE_BSP_LS_On(LOAD_SWITCH_FLASH);
-  HAL_Delay(100);
+  HAL_Delay(LOAD_SWITCH_FLASH_DELAY_MS);
 
   APP_PPRINTF("\r\n 2) Attempting to read & write to external flash \r\n");
   flash_read_write();

--- a/Software/app/freefall_lorawan/sys_app.c
+++ b/Software/app/freefall_lorawan/sys_app.c
@@ -83,11 +83,10 @@ void SystemApp_Init(void)
   /* Set load switch */
   GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
   GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
-  HAL_Delay(100);
+  HAL_Delay(LOAD_SWITCH_SENSORS_DELAY_MS);
 
   /* Set I2C interface */
   GNSE_BSP_Sensor_I2C1_Init();
-  HAL_Delay(100);
 
   /* Set accelerometer */
   if (GNSE_ACC_Init() != ACC_OP_SUCCESS)

--- a/Software/app/secure_element_lorawan/sys_app.c
+++ b/Software/app/secure_element_lorawan/sys_app.c
@@ -81,7 +81,7 @@ void SystemApp_Init(void)
   APP_PPRINTF("\r\n Powering and using HW secure element (ATECC608A-TNGLORA) \r\n");
   GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
   GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
-  HAL_Delay(100);
+  HAL_Delay(LOAD_SWITCH_SENSORS_DELAY_MS);
   GNSE_BSP_Sensor_I2C1_Init();
 
   /*Init low power manager*/

--- a/Software/lib/GNSE_BSP/GNSE_bsp_gpio.c
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_gpio.c
@@ -270,7 +270,6 @@ static void BUTTON_SW1_EXTI_Callback(void)
   *         This parameter can be one of the following values:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LS_Init(Load_Switch_TypeDef loadSwitch)
@@ -298,7 +297,6 @@ int32_t GNSE_BSP_LS_Init(Load_Switch_TypeDef loadSwitch)
   *         This parameter can be one of the following values:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
   * @note Load Switch DeInit does not disable the GPIO clock nor disable the Mfx
   * @return GNSE_BSP status
   */
@@ -319,7 +317,8 @@ int32_t GNSE_BSP_LS_DeInit(Load_Switch_TypeDef loadSwitch)
   *         This parameter can be one of the following values:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
+  * @note   Turning on the load switch and powering the peripherals takes some time
+            See SENSORS_LOAD_SWITCH_DELAY_MS and FLASH_LOAD_SWITCH_DELAY_MS
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LS_On(Load_Switch_TypeDef loadSwitch)
@@ -335,7 +334,8 @@ int32_t GNSE_BSP_LS_On(Load_Switch_TypeDef loadSwitch)
   *         This parameter can be one of the following values:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
+  * @note   The power off time of the load switch is 22 us
+  *         (and peripherals have an additional power on time)
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LS_Off(Load_Switch_TypeDef loadSwitch)
@@ -351,7 +351,6 @@ int32_t GNSE_BSP_LS_Off(Load_Switch_TypeDef loadSwitch)
   *         This parameter can be one of the following values:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LS_Toggle(Load_Switch_TypeDef loadSwitch)
@@ -367,7 +366,6 @@ int32_t GNSE_BSP_LS_Toggle(Load_Switch_TypeDef loadSwitch)
   *         This parameter can be one of following parameters:
   *            @arg LOAD_SWITCH1
   *            @arg LOAD_SWITCH2
-  *            @arg LOAD_SWITCH3
   * @return Load Switch status
   */
 int32_t GNSE_BSP_LS_GetState(Load_Switch_TypeDef loadSwitch)

--- a/Software/lib/GNSE_BSP/GNSE_bsp_gpio.h
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_gpio.h
@@ -132,6 +132,22 @@ typedef enum
 #define LOAD_SWITCH2_GPIO_CLK_ENABLE() __HAL_RCC_GPIOC_CLK_ENABLE()
 #define LOAD_SWITCH2_GPIO_CLK_DISABLE() __HAL_RCC_GPIOC_CLK_DISABLE()
 
+/*!
+ * Load Switch delay time defines in ms
+ * There are two load switches: one for the flash IC, the other for the sensors and secure element
+ * All values are rounded up (and increased) to ensure functionality.
+ * Delay values (Load Switch and sensor have to be added together for the full delay time)
+ * Load Switch:                 typ. 120-200 us
+ * Flash IC:                    min. 800 us
+ * Secure Element:              min. 100 us
+ * Temperature/Humidity sensor: max. 240 us
+ * Accelerometer:               tested to 5 ms, but could vary in different temperatures (datasheet does not define power on time)
+ */
+#define LOAD_SWITCH_SENSORS_DELAY_MS 10U
+#define LOAD_SWITCH_FLASH_DELAY_MS 5U
+#define LOAD_SWITCH1_DELAY_MS LOAD_SWITCH_SENSORS_DELAY_MS
+#define LOAD_SWITCH2_DELAY_MS LOAD_SWITCH_FLASH_DELAY_MS
+
 #define LOAD_SWITCHx_GPIO_CLK_ENABLE(__INDEX__) \
   do                                            \
   {                                             \

--- a/Software/lib/GNSE_HAL/GNSE_hal.c
+++ b/Software/lib/GNSE_HAL/GNSE_hal.c
@@ -38,8 +38,7 @@ void GNSE_HAL_Internal_Sensors_Init(void)
 {
     GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
     GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
-    /* Delay required to let the sensors start up */
-    HAL_Delay(GNSE_HAL_INIT_DELAY);
+    HAL_Delay(LOAD_SWITCH_SENSORS_DELAY_MS);
 
     GNSE_ACC_Init();
     SHTC3_probe();
@@ -67,7 +66,7 @@ void GNSE_HAL_Flash_Init(void)
 {
     GNSE_BSP_LS_Init(LOAD_SWITCH_FLASH);
     GNSE_BSP_LS_On(LOAD_SWITCH_FLASH);
-    HAL_Delay(GNSE_HAL_INIT_DELAY);
+    HAL_Delay(LOAD_SWITCH_FLASH_DELAY_MS);
     MX25R16_Init(&GNSE_HAL_Flash);
 }
 

--- a/Software/lib/GNSE_HAL/GNSE_hal.h
+++ b/Software/lib/GNSE_HAL/GNSE_hal.h
@@ -30,8 +30,6 @@ extern "C" {
 #include <stdbool.h>
 #include "MX25R16.h"
 
-#define GNSE_HAL_INIT_DELAY 100U // TODO: Decrease value to settling time, see https://github.com/TheThingsIndustries/generic-node-se/issues/153
-
 extern MxChip GNSE_HAL_Flash;
 
 /**


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

I've changed the load switch function to include a delay instead of randomly doing a 100 ms delay each time. Closes #153.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Load switch includes a delay parameter
- Defined power on delays for all peripherals connected to the load switch
-  Removed the 100 ms delays.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Only basic, basic_lorawan, and secure_element_lorawan have changed.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

[datasheet load switch](https://www.ti.com/lit/ds/symlink/tps22917.pdf?ts=1616407256180&ref_url=https%253A%252F%252Fwww.google.com%252F) page 6, since we use 2.8V (Ct open) it should be between 120 us and 200 us.
![image](https://user-images.githubusercontent.com/77615373/112169592-9e5a5a00-8bf2-11eb-841a-fb9ee39431fe.png)
[datasheet flash](https://pdf1.alldatasheet.com/datasheet-pdf/view/694008/MCNIX/MX25R1635F/+4J4Q2-VKCMpZcPbNCZY.DGR+/datasheet.pdf) page 79
![image](https://user-images.githubusercontent.com/77615373/112169452-7ec33180-8bf2-11eb-88bc-c531ba4297f9.png)
[datasheet se](https://ww1.microchip.com/downloads/en/DeviceDoc/ATECC608A-for-LoRaWAN-Data-Sheet-DS40002154B.pdf) page 65
![image](https://user-images.githubusercontent.com/77615373/112169329-65ba8080-8bf2-11eb-8d0e-560b8ea1d8cb.png)
[datasheet sht](https://media.digikey.com/pdf/Data%20Sheets/Sensirion%20PDFs/HT_DS_SHTC3_D1.pdf) page 4
![image](https://user-images.githubusercontent.com/77615373/112170248-335d5300-8bf3-11eb-818f-d83301f0ab36.png)

Only the accelerometer did not have any time listed in the datasheet. It does mention times between operating modes (~1.6 ms), but no proper start up delay. I tested with a few parameters and saw that a delay of 5 ms was enough to get the accelerometer operational (I added 1 extra just to be safe). The other values were also tested (I moved the load switch functions just before initialisation and removed the UART functions for a proper test).




