### PR TITLE
lib,app: Add downlink handler with buzzer tunes

### DIFF
--- a/Software/app/README.md
+++ b/Software/app/README.md
@@ -13,12 +13,12 @@ The device enters stop mode in between transmissions to reduce power consumption
 
 [basic_freertos](./basic_freertos) contains a basic FreeRTOS low power application that creates two threads and passes messages via a queue triggering a blinking LED with each passed message.
 
-[freefall_lorawan](./freefall_lorawan) contains a simple application to join via OTAA and waits to send a message until the device is free-falling
+[freefall_lorawan](./freefall_lorawan) contains a simple application to join via OTAA and waits to send a message until the device is free-falling. A downlink on port 1 will cause the buzzer to beep, which can be turned off with a button press.
 
 [freertos_lorawan](./basic_freertos) contains a multi-thread FreeRTOS LoRaWAN Class A demo app that joins over OTAA and sends uplink data.
 
 [secure_element_lorawan](./secure_element_lorawan) contains a LoRaWAN application where a class A device joins via OTAA (LoRaWAN v1.0.2) using a HW secure element (ATECC608A-TNGLORA) and sends dummy payloads triggered by a time interval.
-This app doesn't require LoRaWAN keys/EUI configurations. Follow this [tuturial](https://www.thethingsindustries.com/docs/devices/claim-atecc608a/) to claim your device, and your device will join via OTAA automatically.
+This app doesn't require LoRaWAN keys/EUI configurations. Follow this [tutorial](https://www.thethingsindustries.com/docs/devices/claim-atecc608a/) to claim your device, and your device will join via OTAA automatically.
 
 ## Applications configuration
 

--- a/Software/app/basic_lorawan/lora_app.c
+++ b/Software/app/basic_lorawan/lora_app.c
@@ -174,7 +174,7 @@ void LoRaWAN_Init(void)
 
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 {
-  if (GPIO_Pin == BUTTON_SW1)
+  if (GPIO_Pin == BUTTON_SW1_PIN)
   {
     /* Note: when "EventType == TX_ON_TIMER" this GPIO is not initialised */
     UTIL_SEQ_SetTask((1 << CFG_SEQ_Task_LoRaSendOnTxTimerOrButtonEvent), CFG_SEQ_Prio_0);

--- a/Software/app/basic_lorawan/stm32wlxx_it.c
+++ b/Software/app/basic_lorawan/stm32wlxx_it.c
@@ -125,6 +125,14 @@ void EXTI1_IRQHandler(void)
   HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_1);
 }
 
+/**
+  * @brief This function handles EXTI Line 3 Interrupt.
+  */
+void EXTI3_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
+}
+
 void USART2_IRQHandler(void)
 {
   HAL_UART_IRQHandler(&GNSE_BSP_debug_usart);

--- a/Software/app/basic_lorawan/stm32wlxx_it.h
+++ b/Software/app/basic_lorawan/stm32wlxx_it.h
@@ -35,6 +35,7 @@ void SysTick_Handler(void);
 void TAMP_STAMP_LSECSS_SSRU_IRQHandler(void);
 void EXTI0_IRQHandler(void);
 void EXTI1_IRQHandler(void);
+void EXTI3_IRQHandler(void);
 void DMA1_Channel5_IRQHandler(void);
 void USART2_IRQHandler(void);
 void RTC_Alarm_IRQHandler(void);

--- a/Software/app/freefall_lorawan/conf/app_conf.h
+++ b/Software/app/freefall_lorawan/conf/app_conf.h
@@ -58,9 +58,17 @@
 #define ACC_FF_ODR LIS2DH12_ODR_100Hz
 
 /**
- * This variable sets the LoRaWAN transmission port of Freefall events
+ * This variable sets the LoRaWAN transmission port of free fall events
  */
 #define ACC_FF_LORA_PORT 2
+
+/**
+ * Downlink defs
+ */
+/* This variable sets the LoRaWAN downlink port for locally indicating free fall events */
+#define ACC_FF_DOWNLINK_PORT 1
+/* Time in milliseconds the downlink callback (controlling the buzzer) will be initiated */
+#define ACC_FF_DOWNLINK_TIME_MS 2000
 
 /**
   * Supported requester to the MCU Low Power Manager - can be increased up  to 32
@@ -71,6 +79,7 @@ typedef enum
   CFG_LPM_APPLI_Id,
   CFG_LPM_UART_TX_Id,
   CFG_LPM_TCXO_WA_Id,
+  CFG_LPM_FF_ACC_Id,
 } CFG_LPM_Id_t;
 
 /**

--- a/Software/app/freefall_lorawan/freefall.h
+++ b/Software/app/freefall_lorawan/freefall.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "GNSE_acc.h"
+#include "LmHandler.h"
 
 /**
   * @brief  Sets the accelerometer registers to detect free fall events
@@ -50,6 +51,20 @@ ACC_op_result_t ACC_FreeFall_Disable(void);
   * @return none
   */
 void ACC_FreeFall_IT_Handler(void);
+
+/**
+  * @brief  Handle free fall downlink events
+  * @param  rx_data: Data pointer
+  * @return none
+  */
+void ACC_FreeFall_Downlink_Handler(LmHandlerAppData_t *rx_data);
+
+
+/**
+  * @brief  Function run after pressing the button, turns off all peripherals set after downlink
+  * @return none
+  */
+void ACC_Disable_FreeFall_Notification(void);
 
 #ifdef __cplusplus
 }

--- a/Software/app/freefall_lorawan/lora_app.c
+++ b/Software/app/freefall_lorawan/lora_app.c
@@ -26,6 +26,7 @@
 #include "stm32_lpm.h"
 #include "LmHandler.h"
 #include "lora_info.h"
+#include "freefall.h"
 
 /**
   * @brief  join event callback function
@@ -158,6 +159,7 @@ static void OnRxData(LmHandlerAppData_t *appData, LmHandlerRxParams_t *params)
     static const char *slotStrings[] = {"1", "2", "C", "C Multicast", "B Ping-Slot", "B Multicast Ping-Slot"};
     APP_LOG(ADV_TRACER_TS_OFF, ADV_TRACER_VLEVEL_M, "\r\n ###### D/L FRAME:%04d | SLOT:%s | PORT:%d | DR:%d | RSSI:%d | SNR:%d\r\n",
         params->DownlinkCounter, slotStrings[params->RxSlot], appData->Port, params->Datarate, params->Rssi, params->Snr);
+    ACC_FreeFall_Downlink_Handler(appData);
 }
 
 static void OnJoinRequest(LmHandlerJoinParams_t *joinParams)

--- a/Software/app/freefall_lorawan/stm32wlxx_it.c
+++ b/Software/app/freefall_lorawan/stm32wlxx_it.c
@@ -126,6 +126,14 @@ void EXTI1_IRQHandler(void)
 }
 
 /**
+  * @brief This function handles EXTI Line 3 Interrupt.
+  */
+void EXTI3_IRQHandler(void)
+{
+  HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_3);
+}
+
+/**
   * @brief This function handles EXTI Line 9-5 Interrupt.
   */
 void EXTI9_5_IRQHandler(void)
@@ -161,6 +169,11 @@ void RTC_Alarm_IRQHandler(void)
 void SUBGHZ_Radio_IRQHandler(void)
 {
   HAL_SUBGHZ_IRQHandler(&hsubghz);
+}
+
+void TIM2_IRQHandler(void)
+{
+  HAL_TIM_IRQHandler(&GNSE_BSP_buzzer_timer);
 }
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Software/app/freefall_lorawan/stm32wlxx_it.h
+++ b/Software/app/freefall_lorawan/stm32wlxx_it.h
@@ -35,6 +35,7 @@ void SysTick_Handler(void);
 void TAMP_STAMP_LSECSS_SSRU_IRQHandler(void);
 void EXTI0_IRQHandler(void);
 void EXTI1_IRQHandler(void);
+void EXTI3_IRQHandler(void);
 void EXTI9_5_IRQHandler(void);
 void DMA1_Channel5_IRQHandler(void);
 void USART2_IRQHandler(void);

--- a/Software/app/freefall_lorawan/sys_app.c
+++ b/Software/app/freefall_lorawan/sys_app.c
@@ -108,8 +108,11 @@ void SystemApp_Init(void)
     APP_LOG(ADV_TRACER_TS_ON, ADV_TRACER_VLEVEL_H, "\r\nAccelerometer initialized \r\n");
   }
 
+  /* Set push button interrupt */
+  GNSE_BSP_PB_Init(BUTTON_SW1, BUTTON_MODE_EXTI);
   /* Set free fall events */
   ACC_FreeFall_Enable();
+  BUZZER_SetState(BUZZER_STATE_OFF);
 
   /* Here user can init the board peripherals and sensors */
 
@@ -292,6 +295,10 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
   if (GPIO_Pin == ACC_INT_PIN)
   {
     ACC_FreeFall_IT_Handler();
+  }
+  if (GPIO_Pin == BUTTON_SW1_PIN)
+  {
+    ACC_Disable_FreeFall_Notification();
   }
 }
 

--- a/Software/lib/BUZZER/BUZZER.c
+++ b/Software/lib/BUZZER/BUZZER.c
@@ -34,9 +34,10 @@ static void BUZZER_Warning(void);
 static void BUZZER_Danger(void);
 static void BUZZER_TIM_IRQHandler(TIM_HandleTypeDef *htim);
 
+static bool init_flag = false;
+
 BUZZER_op_result_t BUZZER_Init(void)
 {
-  static bool init_flag = false;
 
   if (init_flag == false)
   {
@@ -56,10 +57,11 @@ BUZZER_op_result_t BUZZER_Init(void)
 
 BUZZER_op_result_t BUZZER_DeInit(void)
 {
-  if (GNSE_BSP_BUZZER_TIM_DeInit(BUZZER_TIM_IRQHandler) != GNSE_BSP_ERROR_NONE)
+  if (GNSE_BSP_BUZZER_TIM_DeInit() != GNSE_BSP_ERROR_NONE)
   {
     return BUZZER_OP_FAIL;
   }
+  init_flag = false;
   return BUZZER_OP_SUCCESS;
 }
 
@@ -191,7 +193,7 @@ BUZZER_state_t BUZZER_GetState(void)
   return buzzer_state;
 }
 
-void BUZZER_TIM_IRQHandler(TIM_HandleTypeDef *htim)
+static void BUZZER_TIM_IRQHandler(TIM_HandleTypeDef *htim)
 {
   if (__HAL_TIM_GET_IT_SOURCE(htim, BUZZER_TIMER_IT) != RESET)
   {

--- a/Software/lib/GNSE_BSP/GNSE_bsp_clk_timer.c
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_clk_timer.c
@@ -91,19 +91,6 @@ void GNSE_BSP_IWDG_Refresh(void)
   HAL_IWDG_Refresh(&GNSE_BSP_iwdg);
 }
 
-int32_t GNSE_BSP_BUZZER_TIM_DeInit(pTIM_CallbackTypeDef cb)
-{
-  if (HAL_TIM_PWM_DeInit(&GNSE_BSP_buzzer_timer) != HAL_OK)
-  {
-    return GNSE_BSP_ERROR_NO_INIT;
-  }
-  if (HAL_TIM_PWM_Stop_IT(&GNSE_BSP_buzzer_timer, BUZZER_TIMER_CHANNEL) != HAL_OK)
-  {
-    return GNSE_BSP_ERROR_NO_INIT;
-  }
-  return GNSE_BSP_ERROR_NONE;
-}
-
 int32_t GNSE_BSP_BUZZER_TIM_Init(pTIM_CallbackTypeDef cb)
 {
   TIM_MasterConfigTypeDef sMasterConfig = {0};
@@ -159,6 +146,19 @@ int32_t GNSE_BSP_BUZZER_TIM_Init(pTIM_CallbackTypeDef cb)
   }
   HAL_TIM_RegisterCallback(&GNSE_BSP_buzzer_timer, HAL_TIM_PERIOD_ELAPSED_CB_ID, cb);
   if (HAL_TIM_PWM_Start_IT(&GNSE_BSP_buzzer_timer, BUZZER_TIMER_CHANNEL) != HAL_OK)
+  {
+    return GNSE_BSP_ERROR_NO_INIT;
+  }
+  return GNSE_BSP_ERROR_NONE;
+}
+
+int32_t GNSE_BSP_BUZZER_TIM_DeInit()
+{
+  if (HAL_TIM_PWM_DeInit(&GNSE_BSP_buzzer_timer) != HAL_OK)
+  {
+    return GNSE_BSP_ERROR_NO_INIT;
+  }
+  if (HAL_TIM_PWM_Stop_IT(&GNSE_BSP_buzzer_timer, BUZZER_TIMER_CHANNEL) != HAL_OK)
   {
     return GNSE_BSP_ERROR_NO_INIT;
   }

--- a/Software/lib/GNSE_BSP/GNSE_bsp_clk_timer.h
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_clk_timer.h
@@ -68,7 +68,7 @@ extern IWDG_HandleTypeDef GNSE_BSP_iwdg;
 #define BUZZER_TIMER_IT TIM_IT_UPDATE
 
 int32_t GNSE_BSP_BUZZER_TIM_Init(pTIM_CallbackTypeDef cb);
-int32_t GNSE_BSP_BUZZER_TIM_DeInit(pTIM_CallbackTypeDef cb);
+int32_t GNSE_BSP_BUZZER_TIM_DeInit();
 
 int32_t GNSE_BSP_RTC_Init(void);
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Add a basic downlink handler utilising the button and the buzzer. Closes #168 and closes #156. Also relates to (closed) issue #167.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added free fall handler and callback, which user can change. Default is first testing the port and then setting the sequencer to beep the buzzer.
- Fixed button implementation in basic_lorawan (and added it in freefall_lorawan)
- Fixed the deinit function for the buzzer.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Downlinks can be any data, it only needs to be on port 1 (which is the default port on TTN). TTN will not send an empty payload btw so at least put something in it. You can also test if you can change this to the data size, data transmitted, etc.. The buzzer should beep afterwards, which is immediately turned off with a simple button press.

This picture shows the power consumption, which visualises the transmission, receiving and periodic buzzer beeps and the release of the buzzer with a button press.
![image](https://user-images.githubusercontent.com/77615373/115200024-16357a80-a0f4-11eb-9183-4c190b3cf055.png)
