### PR TITLE
doc: Update documentation URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ There are many ways to contribute to this project.
 
 ### :mega: Discussions
 
-We love to discuss design decisions, device features and possible use cases with the community, so please use the [forum](https://www.thethingsnetwork.org/forum/). 
+We love to discuss design decisions, device features and possible use cases with the community, so please use the [forum](https://www.thethingsnetwork.org/forum/).
 
 ### :question: Questions
 
@@ -32,13 +32,13 @@ If you see an [open issue](https://github.com/TheThingsIndustries/generic-node-s
 
 ### :books: Documentation
 
-If you see that our documentation is lacking or incorrect, it would be great if you could help us improve it. This will help users and fellow contributors understand how to better develop and use the device. Generic Node documentation [repository](https://github.com/TheThingsIndustries/generic-node-docs) can be viewed at [documentation website](https://thethingsindustries.github.io/generic-node-docs) and you can contribute by following the [documentation contribution guideline](https://github.com/TheThingsIndustries/generic-node-docs/blob/master/CONTRIBUTING.md).
+If you see that our documentation is lacking or incorrect, it would be great if you could help us improve it. This will help users and fellow contributors understand how to better develop and use the device. Generic Node documentation [repository](https://github.com/TheThingsIndustries/generic-node-docs) can be viewed at [documentation website](https://www.genericnode.com/docs/) and you can contribute by following the [documentation contribution guideline](https://github.com/TheThingsIndustries/generic-node-docs/blob/master/CONTRIBUTING.md).
 
 ## Steps to contribute
 
 - [Fork the repository](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository)
 
-- Follow our [getting started](https://thethingsindustries.github.io/generic-node-docs/getting-started/) guides to setup your environment
+- Follow our [getting started](https://www.genericnode.com/docs/getting-started/) guides to setup your environment
 
 - Create a branch following our [branching guideline](#branching-guideline)
 

--- a/Hardware/README.md
+++ b/Hardware/README.md
@@ -13,7 +13,7 @@ The reference design hardware provides the needed resources for device productio
 
 ## Documentation
 
-The [Generic Node documentation website](https://thethingsindustries.github.io/generic-node-docs/) provides information about the hardware features and how to [get started with the hardware development](https://thethingsindustries.github.io/generic-node-docs/getting-started/se-hw/).
+The [Generic Node documentation website](https://www.genericnode.com/docs/) provides information about the hardware features and how to [get started with the hardware development](https://www.genericnode.com/docs/getting-started/se-hw/).
 
 ## Legal
 Copyright © 2021 The Things Industries B.V.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Software libraries and sample applications can be found in [Software](./Software
 
 ## Documentation
 
-The [Generic Node documentation website](https://thethingsindustries.github.io/generic-node-docs/) provides information about the node hardware and software features.
+The [Generic Node documentation website](https://www.genericnode.com/docs/) provides information about the node hardware and software features.
 
 ## Contribution
 

--- a/Software/README.md
+++ b/Software/README.md
@@ -9,7 +9,7 @@ The software provides a boilerplate of applications and libraries that can be us
 
 ## Documentation
 
-The [Generic Node documentation website](https://thethingsindustries.github.io/generic-node-docs/) provides information about the software features and how to [get started with the software development](https://thethingsindustries.github.io/generic-node-docs/getting-started/se-sw/).
+The [Generic Node documentation website](https://www.genericnode.com/docs/) provides information about the software features and how to [get started with the software development](https://www.genericnode.com/docs/getting-started/se-sw/).
 
 ## Legal
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

A small update:
The generic node docs can be found now at https://www.genericnode.com/docs/
instead of the old long link https://thethingsindustries.github.io/generic-node-docs/

