### PR TITLE
SE randomizer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ dkms.conf
 
 # STM32CubeIDE (eclipse)
 *.launch
+
+# Ctags
+tags

--- a/Software/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se-hal.c
+++ b/Software/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se-hal.c
@@ -14,7 +14,7 @@
  */
 
 /**
- * @file hal_LoraMacNode.c
+ * @file atecc608a-tnglora-se-hal.c
  *
  * @copyright Copyright (c) 2021 The Things Industries B.V.
  *
@@ -25,16 +25,22 @@
 
 #include "atca_hal.h"
 #include "atca_device.h"
+#include "atca_basic.h"
 #include "atca_status.h"
 #include "stm32wlxx_hal_dma.h"
 #include "stm32wlxx_hal_i2c.h"
 #include "GNSE_bsp.h"
 
-uint32_t ATECC608ASeHalGetRandomNumber( void )
+uint32_t ATECC608ASeHalGetRandomNumber(void)
 {
-    // Not Implemeted
-    //TODO: Add suppport for random generation, see https://github.com/TheThingsIndustries/generic-node-se/issues/137
-    return 0;
+    uint8_t rand_out[RANDOM_NUM_SIZE];
+    uint32_t rand_ret;
+    if (atcab_random(rand_out) != ATCA_SUCCESS)
+    {
+        return 0;
+    }
+    rand_ret = (rand_out[0] << 24) | (rand_out[1] << 16) | (rand_out[2] << 8) | rand_out[3];
+    return rand_ret;
 }
 
 /** @brief This function delays for a number of microseconds.

--- a/Software/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se.c
+++ b/Software/lib/ATECC608A-TNGLORA/atecc608a-tnglora-se.c
@@ -40,7 +40,6 @@
 #include "secure-element.h"
 #include "se-identity.h"
 #include "atecc608a-tnglora-se-hal.h"
-#include "radio.h"         /* needed for Random */
 
 /*!
  * Number of supported crypto keys
@@ -593,8 +592,8 @@ SecureElementStatus_t SecureElementRandomNumber( uint32_t* randomNum )
     {
         return SECURE_ELEMENT_ERROR_NPE;
     }
-    // *randomNum = ATECC608ASeHalGetRandomNumber( ); // TODO: Add SE support, see https://github.com/TheThingsIndustries/generic-node-se/issues/137
-    *randomNum = Radio.Random( );
+
+    *randomNum = ATECC608ASeHalGetRandomNumber();
     return SECURE_ELEMENT_SUCCESS;
 }
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the secure element's randomizer for generating random numbers. Additionally adds tags to gitignore. Closes #137, #191.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Adds randomizer functionality, which also makes sure that the SE is on as it would otherwise be stuck
- Replaces the instance the randomizer was needed (previously used with radio randomize feature)
- Added 'tags' to gitignore

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Best is to print out the resulting 'rand_in' variables and see these change. Of course, it should join with the OTAA as well.

