### PR TITLE
Flash double initialisation fix

### DIFF
--- a/Software/lib/MX25R1635/MX25R16.c
+++ b/Software/lib/MX25R1635/MX25R16.c
@@ -30,7 +30,6 @@
  */
 int MX25R16_Init(MxChip *Mxic)
 {
-// TODO: Fix issue of system hanging with this function is called more than once, https://github.com/TheThingsIndustries/generic-node-se/issues/173
     int Status;
 
     Mx_printf("\n\tStart initializing the device and controller\r\n");
@@ -53,13 +52,10 @@ int MX25R16_Init(MxChip *Mxic)
     if (Status != MXST_SUCCESS)
         return Status;
 
-    Status = MxSoftwareInit(Mxic, BASEADDRESS);
-    if (Status != MXST_SUCCESS)
-        return Status;
-
-    Status = MxChangeMode(Mxic, MODE_SPI,SELECT_3B);
-    if (Status != MXST_SUCCESS)
-        return Status;
+    MxSpi *Spi = Mxic->Priv;
+    Mxic->AppGrp._Read = (Spi->CurAddrMode==SELECT_3B) ? MxREAD : ((Mxic->SPICmdList[MX_RD_CMDS] & MX_4B_RD) ? MxREAD4B : MxREAD);
+    Mxic->AppGrp._Write = (Spi->CurAddrMode==SELECT_3B) ? MxPP : ((Mxic->SPICmdList[MX_RD_CMDS] & MX_4B_RD) ? MxPP4B : MxPP);
+    Mxic->AppGrp._Erase = (Spi->CurAddrMode==SELECT_3B) ? MxBE : ((Mxic->SPICmdList[MX_RD_CMDS] & MX_4B_RD) ? MxBE4B : MxBE);
 
     return MXST_SUCCESS;
 }

--- a/Software/lib/MX25R1635/MX25R16.h
+++ b/Software/lib/MX25R1635/MX25R16.h
@@ -23,6 +23,11 @@
 #ifndef MX25R16_H_
 #define MX25R16_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "nor_ops.h"
 #include "mx_test.h"
 
@@ -45,5 +50,9 @@ int MXR2516_Suspend(MxChip *Mxic);
 int MXR2516_Resume(MxChip *Mxic);
 
 int MxCalibration(MxChip *Mxic);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MX25R16_H_ */

--- a/Software/lib/MX25R1635/mx_define.h
+++ b/Software/lib/MX25R1635/mx_define.h
@@ -23,6 +23,11 @@
 #ifndef MX_DEFINE_H
 #define MX_DEFINE_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #define PLATFORM_GNSE 1
 
 #if PLATFORM_GNSE
@@ -164,4 +169,8 @@ typedef struct
  *     hardware_test.h
  */
 
+#ifdef __cplusplus
+}
 #endif
+
+#endif /* MX_DEFINE_H */

--- a/Software/lib/MX25R1635/mx_test.h
+++ b/Software/lib/MX25R1635/mx_test.h
@@ -10,6 +10,11 @@
 #ifndef MX_TEST_H_
 #define MX_TEST_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**************Request*******************/
 #define PAGE     0
 #define SECTOR   1
@@ -51,4 +56,9 @@
 int MxSimpleTest(MxChip *Mxic);
 int MxComplicatedTest(MxChip *Mxic);
 u32 MxRequestAddress(u8 request_size);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MX_TEST_H_ */

--- a/Software/lib/MX25R1635/mxic_hc.h
+++ b/Software/lib/MX25R1635/mxic_hc.h
@@ -23,6 +23,11 @@
 #ifndef MXIC_HC_H_
 #define MXIC_HC_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "mx_define.h"
 /*
  * define TransFlag
@@ -106,5 +111,9 @@ enum HardwareMode
 
 int MxHardwareInit(MxSpi *Spi);
 int MxPolledTransfer(MxSpi *Spi, u8 *WrBuf, u8 *RdBuf, u32 ByteCount);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MXIC_HC_H_ */

--- a/Software/lib/MX25R1635/nor_cmd.h
+++ b/Software/lib/MX25R1635/nor_cmd.h
@@ -11,6 +11,11 @@
 #ifndef NOR_CMD_H_
 #define NOR_CMD_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "spi.h"
 
 struct _MxChip;
@@ -541,5 +546,9 @@ int MxNOP(MxChip *Mxic);
 
 int MxWaitForFlashReady(MxChip *Mxic,u32 ExpectTime);
 int MxIsFlashBusy(MxChip *Mxic);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* NOR_CMD_H_ */

--- a/Software/lib/MX25R1635/nor_ops.h
+++ b/Software/lib/MX25R1635/nor_ops.h
@@ -11,6 +11,11 @@
 #ifndef NOR_OPS_H_
 #define NOR_OPS_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "nor_cmd.h"
 
 /*
@@ -80,4 +85,9 @@ int MxPwdAuth(MxChip *Mxic, u8 *Password);
 int MxDpbLock(MxChip *Mxic, u32 Addr, u64 Len);
 int MxDpbUnlock(MxChip *Mxic, u32 Addr, u64 Len);
 int MxDpbIsLocked(MxChip *Mxic, u32 Addr, u64 Len);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* NOR_OPS_H_ */

--- a/Software/lib/MX25R1635/spi.h
+++ b/Software/lib/MX25R1635/spi.h
@@ -11,9 +11,18 @@
 #ifndef SPI_H_
 #define SPI_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "mxic_hc.h"
 
 int MxSpiFlashWrite(MxSpi *Spi, u32 Addr, u32 ByteCount, u8 *WrBuf, u8 WrCmd);
 int MxSpiFlashRead(MxSpi *Spi, u32 Addr, u32 ByteCount, u8 *RdBuf, u8 RdCmd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SPI_H_ */


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR has alterations to the flash IC initialisation function relating to to a bug occurring when it is called more than once. It also makes the flash IC build with C++. Closes #173 #189.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Removed MxChangeMode as this function does not work when the handler is cleared by memset. I opted for removing this function rather than MxSoftwareInit since it would require less code in Mx25R16_Init (only four lines of MxChangeMode were needed).
- Removed the unnecessary second MxSoftwareInit function call.
- Added C++ guards to avoid conflicts with C code with a C++ compiler.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

I tested by calling MX25R16_Init three times and seeing if the tests could pass.

Should you want to test if the C++ functionality (not as important as testing if it builds regularly of course) it only really matters if the files are .cpp as well. It is only meant to protect when users want to add their own C++ code to it (like was done with both SHTC3 and LIS2DH12 libraries).

