### PR TITLE
FreeRTOS downlink fix

### DIFF
--- a/Software/app/freertos_lorawan/classa_task.c
+++ b/Software/app/freertos_lorawan/classa_task.c
@@ -116,13 +116,6 @@ void vLorawanClassATask( void * params )
     }
     else
     {
-        /*
-         * Adaptive data rate is set to ON by default but this can be changed runtime if needed
-         * for mobile devices with no fixed locations.
-         */
-
-        LoRaWAN_SetAdaptiveDataRate( true );
-
         /**
          * Successfully joined a LoRaWAN network. Now the  task runs in an infinite loop,
          * sends periodic uplink message of 1 byte by obeying fair access policy for the LoRaWAN network.

--- a/Software/app/freertos_lorawan/conf/lorawan_conf.h
+++ b/Software/app/freertos_lorawan/conf/lorawan_conf.h
@@ -82,7 +82,7 @@ extern "C" {
 /**
  * @brief Interval between retry attempts for OTAA join.
  * It waits for a retry interval +- random jitter ( to avoid dos ) before attempting to
- * join again with LoRaWAN network.
+ * join again with a LoRaWAN network.
  */
 #define lorawanConfigJOIN_RETRY_INTERVAL_MS    ( 2000 )
 
@@ -98,9 +98,9 @@ extern "C" {
  * @brief Default config to enable or disable adaptive data rate.
  *
  * Enabling adaptive data rate allows the network to set optimized data rates for end devices
- * thereby optimizing on air time and power consumption. Its recommended to enable adaptive
+ * thereby optimizing on air time and power consumption. It is recommended to enable adaptive
  * data rate for static devices and devices with stable RF conditions.
- * Adaptive data rate can be toggled runtime using API.
+ * Adaptive data rate can be toggled at runtime using the API.
  *
  */
 #define lorawanConfigADR_ON    ( 1 )
@@ -114,7 +114,7 @@ extern "C" {
 /**
  * @brief Overall timing error threshold for the system.
  */
-#define lorawanConfigRX_MAX_TIMING_ERROR    ( 50 )
+#define lorawanConfigRX_MAX_TIMING_ERROR    ( 200 )
 
 /**
  * @brief Maximum payload length defined by LoRaWAN spec


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR increases the window of the RX retrieval. Additionally it removes the forced ADR sequence and fixes some documentation. Closes #201 #187.
<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Increase the RX error by 150, allowing the retrieval to start just below 5s.
- Remove the ADR enable sequence at the start, as this was already handled with a variable.
- Improve some documentation.

See the graph here:
|basic_lorawan |freertos_lorawan | (new) freertos
|---|---|---|
|5s14ms | 5s129ms |4s980ms|
|218ms|271ms |531ms|
|781ms | 754ms | 492ms|
|218ms | 271ms |531ms| 


Here a picture of the events (compared to the picture in issue #187)
![image](https://user-images.githubusercontent.com/77615373/124087231-1afe9f00-da52-11eb-879e-459737ef1666.png)

Noticeable from both is that the retrieval times are now within the basic_lorawan application's retrieval window, but also extend far beyond this. So the power consumption is increased by this. I choose 200 specifically as it would be slightly before the 5s mark.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Downlinks seem to be better, although not always perfect for me, although this happens with basic_lorawan as well so this can be due to the setup/antenna performance


