### PR TITLE
Generalized system clock call and error handler

### DIFF
--- a/Software/app/basic/main.c
+++ b/Software/app/basic/main.c
@@ -21,9 +21,7 @@
  */
 
 #include "app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
+#include "GNSE_hal.h"
 
 void led_toggle(uint8_t n_toggles, uint32_t toggle_delay);
 void buzzer_play(uint8_t n_plays, uint32_t play_delay);
@@ -42,7 +40,10 @@ int main(void)
 {
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
 
   /* Initialize Tracer/Logger */
   GNSE_TRACER_INIT();
@@ -93,54 +94,4 @@ int main(void)
     HAL_Delay(100);
   }
   return 0;
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-static void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_OFF;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-static void Error_Handler(void)
-{
-  while (1)
-  {
-  }
 }

--- a/Software/app/basic_bootloader/CMakeLists.txt
+++ b/Software/app/basic_bootloader/CMakeLists.txt
@@ -5,9 +5,10 @@ file(GLOB MAIN_SRC
     "${PROJECT_SOURCE_DIR}/app/basic_bootloader/*.c"
     "${PROJECT_SOURCE_DIR}/target/*.c"
     "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/*.c"
-    "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/GNSE_flash.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/*.c"
     "${PROJECT_SOURCE_DIR}/lib/MCU_FLASH/*.c"
     "${PROJECT_SOURCE_DIR}/lib/Utilities/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/*.c"
     "${PROJECT_SOURCE_DIR}/lib/SPIFFS/*.c"
     "${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER/adv_tracer/*.c"
     "${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER/tiny_printf/*.c"
@@ -36,6 +37,7 @@ target_include_directories(${PROJECT_NAME}.elf
     ${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER
     ${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER/adv_tracer
     ${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER/tiny_printf
+    ${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal
     ${PROJECT_SOURCE_DIR}/lib/SHTC3
     ${PROJECT_SOURCE_DIR}/lib/MX25R1635
     ${PROJECT_SOURCE_DIR}/lib/LIS2DH12

--- a/Software/app/basic_bootloader/main.c
+++ b/Software/app/basic_bootloader/main.c
@@ -21,16 +21,17 @@
  */
 
 #include "app.h"
+#include "GNSE_hal.h"
 #include "bootloader.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 int main(void)
 {
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
 
   /* Initialize Tracer/Logger */
   GNSE_TRACER_INIT();
@@ -63,55 +64,5 @@ int main(void)
   Bootloader_DeInit();
   Bootloader_Jump();
 
-  Error_Handler();
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-static void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_OFF;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3 | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-static void Error_Handler(void)
-{
-  while (1)
-  {
-  }
+  GNSE_HAL_Error_Handler();
 }

--- a/Software/app/basic_fuota/main.c
+++ b/Software/app/basic_fuota/main.c
@@ -20,14 +20,10 @@
  *
  */
 
-#include "GNSE_bsp.h"
-#include "GNSE_lpm.h"
+#include "GNSE_hal.h"
 #include "stm32_seq.h"
 #include "sys_app.h"
 #include "lora_app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 void MX_LoRaWAN_Init(void)
 {
@@ -43,72 +39,13 @@ void MX_LoRaWAN_Process(void)
 int main(void)
 {
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
   MX_LoRaWAN_Init();
   while (1)
   {
     MX_LoRaWAN_Process();
-  }
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure LSE Drive Capability
-  */
-  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
-                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
-                              |RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-void Error_Handler(void)
-{
-  /* User can add his own implementation to report the HAL error return state
-  * A basic Implementation below
-  * TODO: Improve with system wide error handler, see https://github.com/TheThingsIndustries/generic-node-se/issues/57
-  */
-  GNSE_BSP_LED_Init(LED_RED);
-  GNSE_BSP_LED_On(LED_RED);
-  GNSE_LPM_EnterLowPower();
-  while (1)
-  {
   }
 }

--- a/Software/app/basic_lorawan/main.c
+++ b/Software/app/basic_lorawan/main.c
@@ -20,14 +20,10 @@
  *
  */
 
-#include "GNSE_bsp.h"
-#include "GNSE_lpm.h"
+#include "GNSE_hal.h"
 #include "stm32_seq.h"
 #include "sys_app.h"
 #include "lora_app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 void MX_LoRaWAN_Init(void)
 {
@@ -43,72 +39,13 @@ void MX_LoRaWAN_Process(void)
 int main(void)
 {
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
   MX_LoRaWAN_Init();
   while (1)
   {
     MX_LoRaWAN_Process();
-  }
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure LSE Drive Capability
-  */
-  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
-                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
-                              |RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-void Error_Handler(void)
-{
-  /* User can add his own implementation to report the HAL error return state
-  * A basic Implementation below
-  * TODO: Improve with system wide error handler, see https://github.com/TheThingsIndustries/generic-node-se/issues/57
-  */
-  GNSE_BSP_LED_Init(LED_RED);
-  GNSE_BSP_LED_On(LED_RED);
-  GNSE_LPM_EnterLowPower();
-  while (1)
-  {
   }
 }

--- a/Software/app/freefall_lorawan/main.c
+++ b/Software/app/freefall_lorawan/main.c
@@ -20,14 +20,10 @@
  *
  */
 
-#include "GNSE_bsp.h"
-#include "GNSE_lpm.h"
+#include "GNSE_hal.h"
 #include "stm32_seq.h"
 #include "sys_app.h"
 #include "lora_app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 void MX_LoRaWAN_Init(void)
 {
@@ -43,72 +39,13 @@ void MX_LoRaWAN_Process(void)
 int main(void)
 {
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
   MX_LoRaWAN_Init();
   while (1)
   {
     MX_LoRaWAN_Process();
-  }
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure LSE Drive Capability
-  */
-  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
-                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
-                              |RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-void Error_Handler(void)
-{
-  /* User can add his own implementation to report the HAL error return state
-  * A basic Implementation below
-  * TODO: Improve with system wide error handler, see https://github.com/TheThingsIndustries/generic-node-se/issues/57
-  */
-  GNSE_BSP_LED_Init(LED_RED);
-  GNSE_BSP_LED_On(LED_RED);
-  GNSE_LPM_EnterLowPower();
-  while (1)
-  {
   }
 }

--- a/Software/app/secure_element_lorawan/CMakeLists.txt
+++ b/Software/app/secure_element_lorawan/CMakeLists.txt
@@ -19,6 +19,12 @@ file(GLOB LORAWAN_SRC
     "${PROJECT_SOURCE_DIR}/lib/GNSE_TRACER/tiny_printf/*.c"
     "${PROJECT_SOURCE_DIR}/lib/Utilities/baremetal/*.c"
     "${PROJECT_SOURCE_DIR}/lib/GNSE_BSP/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/GNSE_HAL/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/SPIFFS/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/SHTC3/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/MX25R1635/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/LIS2DH12/*.c"
+    "${PROJECT_SOURCE_DIR}/lib/BUZZER/*.c"
     "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/LoRaWAN/Utilities/*.c"
     "${PROJECT_SOURCE_DIR}/${LORAWAN_DIR}/SubGHz_Phy/stm32_radio_driver/*.c"
 
@@ -56,6 +62,12 @@ target_include_directories(lorawan
     ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/conf
     ${PROJECT_SOURCE_DIR}/app/secure_element_lorawan/lib_dependency
     ${PROJECT_SOURCE_DIR}/lib/GNSE_BSP
+    ${PROJECT_SOURCE_DIR}/lib/GNSE_HAL
+    ${PROJECT_SOURCE_DIR}/lib/SPIFFS
+    ${PROJECT_SOURCE_DIR}/lib/SHTC3
+    ${PROJECT_SOURCE_DIR}/lib/MX25R1635
+    ${PROJECT_SOURCE_DIR}/lib/LIS2DH12
+    ${PROJECT_SOURCE_DIR}/lib/BUZZER
     )
 target_compile_definitions(lorawan
     PUBLIC

--- a/Software/app/secure_element_lorawan/main.c
+++ b/Software/app/secure_element_lorawan/main.c
@@ -20,14 +20,10 @@
  *
  */
 
-#include "GNSE_bsp.h"
-#include "GNSE_lpm.h"
+#include "GNSE_hal.h"
 #include "stm32_seq.h"
 #include "sys_app.h"
 #include "lora_app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 void MX_LoRaWAN_Init(void)
 {
@@ -43,72 +39,13 @@ void MX_LoRaWAN_Process(void)
 int main(void)
 {
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
   MX_LoRaWAN_Init();
   while (1)
   {
     MX_LoRaWAN_Process();
-  }
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure LSE Drive Capability
-  */
-  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
-                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
-                              |RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-void Error_Handler(void)
-{
-  /* User can add his own implementation to report the HAL error return state
-  * A basic Implementation below
-  * TODO: Improve with system wide error handler, see https://github.com/TheThingsIndustries/generic-node-se/issues/57
-  */
-  GNSE_BSP_LED_Init(LED_RED);
-  GNSE_BSP_LED_On(LED_RED);
-  GNSE_LPM_EnterLowPower();
-  while (1)
-  {
   }
 }

--- a/Software/app/sensors_lorawan/main.c
+++ b/Software/app/sensors_lorawan/main.c
@@ -20,14 +20,10 @@
  *
  */
 
-#include "GNSE_bsp.h"
-#include "GNSE_lpm.h"
+#include "GNSE_hal.h"
 #include "stm32_seq.h"
 #include "sys_app.h"
 #include "lora_app.h"
-
-static void SystemClock_Config(void);
-static void Error_Handler(void);
 
 void MX_LoRaWAN_Init(void)
 {
@@ -43,72 +39,13 @@ void MX_LoRaWAN_Process(void)
 int main(void)
 {
   HAL_Init();
-  SystemClock_Config();
+  if (GNSE_HAL_SysClk_Init() != GNSE_HAL_OP_SUCCESS)
+  {
+    GNSE_HAL_Error_Handler();
+  }
   MX_LoRaWAN_Init();
   while (1)
   {
     MX_LoRaWAN_Process();
-  }
-}
-
-/**
-  * @brief System Clock Configuration
-  * @return None
-  */
-void SystemClock_Config(void)
-{
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
-
-  /** Configure LSE Drive Capability
-  */
-  __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
-  /** Initializes the CPU, AHB and APB busses clocks
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE|RCC_OSCILLATORTYPE_MSI;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  RCC_OscInitStruct.MSIState = RCC_MSI_ON;
-  RCC_OscInitStruct.MSICalibrationValue = RCC_MSICALIBRATION_DEFAULT;
-  RCC_OscInitStruct.MSIClockRange = RCC_MSIRANGE_11;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-  /** Configure the SYSCLKSource, HCLK, PCLK1 and PCLK2 clocks dividers
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK3|RCC_CLOCKTYPE_HCLK
-                              |RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_PCLK1
-                              |RCC_CLOCKTYPE_PCLK2;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_MSI;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLK3Divider = RCC_SYSCLK_DIV1;
-
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @return None
-  */
-void Error_Handler(void)
-{
-  /* User can add his own implementation to report the HAL error return state
-  * A basic Implementation below
-  * TODO: Improve with system wide error handler, see https://github.com/TheThingsIndustries/generic-node-se/issues/57
-  */
-  GNSE_BSP_LED_Init(LED_RED);
-  GNSE_BSP_LED_On(LED_RED);
-  GNSE_LPM_EnterLowPower();
-  while (1)
-  {
   }
 }

--- a/Software/lib/GNSE_HAL/GNSE_hal.h
+++ b/Software/lib/GNSE_HAL/GNSE_hal.h
@@ -42,10 +42,21 @@ typedef struct GNSE_HAL_Ctx_s
     bool buzzer_init;
 } GNSE_HAL_Ctx_t;
 
+/**
+ * GNSE HAL return types
+ */
+typedef enum
+{
+    GNSE_HAL_OP_SUCCESS = 0,
+    GNSE_HAL_OP_FAIL = 1,
+} GNSE_HAL_op_result_t;
+
 void GNSE_HAL_Init(GNSE_HAL_Ctx_t gnse_inits);
 void GNSE_HAL_DeInit(GNSE_HAL_Ctx_t gnse_deinits);
 void GNSE_HAL_Internal_Sensors_Init(void);
 void GNSE_HAL_Internal_Sensors_DeInit(void);
+GNSE_HAL_op_result_t GNSE_HAL_SysClk_Init(void);
+void GNSE_HAL_Error_Handler(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes most (baremetal) applications use a single system clock configuration and error handler. These were previously included with the main.c. Related to #57.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- New HAL clock file with standard clock configuration
- Replace all SystemClock_Config in baremetal applications (keeping ErrorHandler in the function, as it would produce warnings otherwise)
- Same two steps for Error_Handler
- Updated CMakeLists.txt for secure_element_lorawan and basic_bootloader as they did not include GNSE_HAL. STM32CubeIDE was already up-to-date on this.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

I excluded the RTOS applications as I think they are more suited with their own unique clock config and error handling method. Same for app_template.

One thing that could also be changed is that the error handler is used for the systemclock config. I wanted to replicate the functionality completely but maybe it is kinda out of place with the other function calls that also don't use the error handler, 
