### PR TITLE
Improve free fall application power consumption.

### DIFF
--- a/Software/app/basic/basic_se_flash.c
+++ b/Software/app/basic/basic_se_flash.c
@@ -35,7 +35,7 @@ static void print_buffer(const char *message, uint8_t *buffer, size_t buffer_siz
 
 void secure_element_read_info(void)
 {
-    // Initialize the on boarad secure element and read serial number
+    // Initialize the on board secure element and read serial number
     ATCAIfaceCfg atecc608_i2c_config;
     uint8_t secure_element_serialnum[ATCA_SERIAL_NUM_SIZE];
     uint8_t secure_element_devEUI[DEV_EUI_SIZE_BYTE];
@@ -51,7 +51,7 @@ void secure_element_read_info(void)
     atecc608_i2c_config.wake_delay = ATCA_HAL_ATECC608A_I2C_WAKEUP_DELAY;
     if (atcab_init(&atecc608_i2c_config) != ATCA_SUCCESS)
     {
-        APP_PPRINTF("\r\n Failed to initialize ATECC608A-TNGLORA secure elelment \r\n");
+        APP_PPRINTF("\r\n Failed to initialize ATECC608A-TNGLORA secure element \r\n");
         return;
     }
 

--- a/Software/app/freefall_lorawan/freefall.c
+++ b/Software/app/freefall_lorawan/freefall.c
@@ -53,7 +53,6 @@ ACC_op_result_t ACC_FreeFall_Enable(void)
     /* Set full scale */
     acc_check += (int8_t)lis2dh12_full_scale_set(&dev_ctx, ACC_FF_SCALE);
 
-
     /* Map interrupt 1 on INT2 pin */
     lis2dh12_ctrl_reg6_t ctrl6_set = {
         .not_used_01 = 0,
@@ -85,6 +84,9 @@ ACC_op_result_t ACC_FreeFall_Enable(void)
         .aoi = 1
     };
     acc_check += (int8_t)lis2dh12_int1_gen_conf_set(&dev_ctx, &accel_cfg);
+
+    /* Set low power, 8 bit data output mode */
+    acc_check += (int8_t)lis2dh12_operating_mode_set(&dev_ctx, LIS2DH12_LP_8bit);
 
     /* See if all checks were passed */
     if (acc_check != 0)

--- a/Software/app/freefall_lorawan/sys_app.c
+++ b/Software/app/freefall_lorawan/sys_app.c
@@ -67,24 +67,26 @@ void SystemApp_Init(void)
   UTIL_TIMER_Init();
 
   /* Initialize the Low Power Manager and Debugger */
-  // TODO: Add support for stop mode, see https://github.com/TheThingsIndustries/generic-node-se/issues/180
 #if defined(DEBUGGER_ON) && (DEBUGGER_ON == 1)
-  GNSE_LPM_Init(GNSE_LPM_SLEEP_DEBUG_MODE);
+  GNSE_LPM_Init(GNSE_LPM_SLEEP_STOP_DEBUG_MODE);
 #elif defined(DEBUGGER_ON) && (DEBUGGER_ON == 0)
-  GNSE_LPM_Init(GNSE_LPM_SLEEP_ONLY_MODE);
+  GNSE_LPM_Init(GNSE_LPM_SLEEP_STOP_MODE);
 #endif
 
   /* Initialize Tracer/Logger */
   GNSE_TRACER_INIT();
   GNSE_TRACER_TIMESTAMP(TimestampNow);
 
+  /* Set I2C interface */
+  GNSE_BSP_Sensor_I2C1_Init();
+
   /* Set load switch */
   GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
   GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
   HAL_Delay(LOAD_SWITCH_SENSORS_DELAY_MS);
 
-  /* Set I2C interface */
-  GNSE_BSP_Sensor_I2C1_Init();
+  /* Set the (unused) SHTC3 in sleep mode */
+  SHTC3_sleep();
 
   /* Set accelerometer */
   if (GNSE_ACC_Init() != ACC_OP_SUCCESS)


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Some minor changes to the free fall application, targeted to make it more power efficient. Closes #180.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Set lis2dh12 to 8-bit output mode
- Set SHTC3 in sleep mode
- Set STM32WL in stop mode
- Minor spelling mistakes I found were fixed

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Lowering the ODR also works, but I think it is more beneficial if the users themself would change this to their liking, and having the standard app be easy to test for free fall events. 
