### PR TITLE
app,lib: Add configurable transmisison intervals

### DIFF
--- a/Software/app/freefall_lorawan/conf/app_conf.h
+++ b/Software/app/freefall_lorawan/conf/app_conf.h
@@ -63,6 +63,7 @@
 
 /**
  * This variable sets the LoRaWAN transmission port of free fall events
+ * @note do not use 224. It is reserved for certification
  */
 #define ACC_FF_LORA_PORT 2
 

--- a/Software/app/sensors_lorawan/conf/app_conf.h
+++ b/Software/app/sensors_lorawan/conf/app_conf.h
@@ -36,10 +36,23 @@
  */
 #define SENSORS_PAYLOAD_APP_PORT        2
 
-/*!
- * Defines the application data transmission duty cycle. 10s, value in [ms].
- */
-#define SENSORS_TX_DUTYCYCLE                            10000
+/*! LoRaWAN application port where sensors downlink interval can be changed (via a downlink)
+ *  @note Payload signifies the amount of seconds
+ * */
+#define SENSORS_DOWNLINK_RX_PORT        1
+/* Max time interval of the RX window in seconds (8640 seconds are in one day) */
+#define SENSORS_RX_MAX_S 8640
+/* Min time interval of the RX window in seconds */
+#define SENSORS_RX_MIN_S 5
+
+/**
+  * RX LED definitions
+  */
+#define SENSORS_LED_RX_PERIOD_MS 200
+#define SENSORS_LED_RX_TOGGLES 5
+
+#define SENSORS_LED_UNHANDLED_RX_PERIOD_MS 200
+#define SENSORS_LED_UNHANDLED_RX_TOGGLES 5
 
 /* LoRaWAN v1.0.2 software based OTAA activation information */
 #define APPEUI                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00

--- a/Software/app/sensors_lorawan/sys_app.c
+++ b/Software/app/sensors_lorawan/sys_app.c
@@ -24,6 +24,7 @@
 #include "stm32_systime.h"
 #include "GNSE_lpm.h"
 #include "GNSE_rtc.h"
+#include "GNSE_bm.h"
 #include "sensors.h"
 
 #define MAX_TS_SIZE (int)16
@@ -67,6 +68,7 @@ void SystemApp_Init(void)
   GNSE_BSP_LS_Init(LOAD_SWITCH_SENSORS);
   GNSE_BSP_LS_On(LOAD_SWITCH_SENSORS);
   HAL_Delay(100);
+  GNSE_BM_Init();
   APP_PPRINTF("\r\n Initializing on-board sensors bus I2C1 \r\n");
   GNSE_BSP_Sensor_I2C1_Init();
   APP_PPRINTF("\r\n Initializing on-board sensors \r\n");
@@ -76,12 +78,14 @@ void SystemApp_Init(void)
 void GNSE_LPM_PreStopModeHook(void)
 {
   GNSE_LPM_SensorBus_Off();
+  GNSE_BM_DeInit();
 }
 
 void GNSE_LPM_PostStopModeHook(void)
 {
   GNSE_TRACER_RESUME();
   GNSE_LPM_SensorBus_Resume();
+  GNSE_BM_Init();
 }
 
 /**

--- a/Software/lib/GNSE_BSP/GNSE_bsp_gpio.c
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_gpio.c
@@ -44,6 +44,7 @@ static void BUTTON_SW1_EXTI_Callback(void);
   *         This parameter can be one of the following values:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LED_Init(Led_TypeDef Led)
@@ -71,6 +72,7 @@ int32_t GNSE_BSP_LED_Init(Led_TypeDef Led)
   *         This parameter can be one of the following values:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @note Led DeInit does not disable the GPIO clock nor disable the Mfx
   * @return GNSE_BSP status
   */
@@ -91,6 +93,7 @@ int32_t GNSE_BSP_LED_DeInit(Led_TypeDef Led)
   *         This parameter can be one of the following values:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LED_On(Led_TypeDef Led)
@@ -106,6 +109,7 @@ int32_t GNSE_BSP_LED_On(Led_TypeDef Led)
   *         This parameter can be one of the following values:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LED_Off(Led_TypeDef Led)
@@ -121,6 +125,7 @@ int32_t GNSE_BSP_LED_Off(Led_TypeDef Led)
   *         This parameter can be one of the following values:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @return GNSE_BSP status
   */
 int32_t GNSE_BSP_LED_Toggle(Led_TypeDef Led)
@@ -136,11 +141,35 @@ int32_t GNSE_BSP_LED_Toggle(Led_TypeDef Led)
   *         This parameter can be one of following parameters:
   *            @arg LED1
   *            @arg LED2
+  *            @arg LED3
   * @return LED status
   */
 int32_t GNSE_BSP_LED_GetState(Led_TypeDef Led)
 {
     return (int32_t)HAL_GPIO_ReadPin(LED_PORT[Led], LED_PIN[Led]);
+}
+
+/**
+  * @brief  Set LED to analog mode for lower power consumption (deinits the LEDs)
+  * @param  Led: LED to be de-init.
+  *         This parameter can be one of the following values:
+  *            @arg LED1
+  *            @arg LED2
+  *            @arg LED3
+  * @return GNSE_BSP status
+  */
+int32_t GNSE_BSP_LED_Analog(Led_TypeDef Led)
+{
+    GPIO_InitTypeDef gpio_init_structure = {0};
+
+    /* Configure the GPIO_LED pin */
+    gpio_init_structure.Pin = LED_PIN[Led];
+    gpio_init_structure.Mode = GPIO_MODE_ANALOG;
+    gpio_init_structure.Pull = GPIO_NOPULL;
+
+    HAL_GPIO_Init(LED_PORT[Led], &gpio_init_structure);
+
+    return GNSE_BSP_ERROR_NONE;
 }
 
 /**

--- a/Software/lib/GNSE_BSP/GNSE_bsp_gpio.h
+++ b/Software/lib/GNSE_BSP/GNSE_bsp_gpio.h
@@ -207,6 +207,7 @@ int32_t GNSE_BSP_LED_On(Led_TypeDef Led);
 int32_t GNSE_BSP_LED_Off(Led_TypeDef Led);
 int32_t GNSE_BSP_LED_Toggle(Led_TypeDef Led);
 int32_t GNSE_BSP_LED_GetState(Led_TypeDef Led);
+int32_t GNSE_BSP_LED_Analog(Led_TypeDef Led);
 
 int32_t GNSE_BSP_PB_Init(Button_TypeDef Button, ButtonMode_TypeDef ButtonMode);
 int32_t GNSE_BSP_PB_DeInit(Button_TypeDef Button);


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Adds configurable transmission intervals via downlinks. Closes #208. 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Tx changed to variable (instead of macro)
- Downlink checks for variables (port, max/min time) configurable by the user and changes (or does not change) the downlink accordingly
- Downlinks have interactive LED blinks (RED==rx payload is wrong, GREEN==rx payload can be used to change the interval) 
- Unused tx led sequence was removed (initial version I made a separate led sequence for, but changed it as it consumed more power needlessly).
- Updated some comments
- (de)init bm with sleep as it caused occasional crashes sometimes
- Add analog function for led to deinit to analog value for lower power consumption

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

TTN default variables are in hex, data is read out as decimal so be mindful what you transmit.
