### PR TITLE
dev: Fix basic_azurertos cmake build with HAL lib linking

### DIFF
--- a/Software/app/basic_azurertos/CMakeLists.txt
+++ b/Software/app/basic_azurertos/CMakeLists.txt
@@ -45,3 +45,7 @@ target_include_directories(${PROJECT_NAME}.elf
     ${PROJECT_SOURCE_DIR}/lib/threadx/common/inc
     ${PROJECT_SOURCE_DIR}/lib/threadx/ports/cortex_m4/gnu/inc
     )
+target_link_libraries(${PROJECT_NAME}.elf
+    PUBLIC
+    hal
+    )


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

A minor fix to #222 PR, where the basic_azurertos CMAKE build is broken.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix basic_azurertos CMAKE build that was broken with the last PR.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

...

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

...
