### PR TITLE
app: Add accelerometer reading delay to basic app

### DIFF
--- a/Software/app/basic/basic_sensor.c
+++ b/Software/app/basic/basic_sensor.c
@@ -96,6 +96,8 @@ void accelerometer_read_data_polling(uint8_t n_reads, uint32_t read_delay)
     /* Set device in continuous mode with 12 bit resol. */
     lis2dh12_operating_mode_set(&dev_ctx, LIS2DH12_HR_12bit);
 
+    HAL_Delay(read_delay);
+
     /* Read samples in polling mode (no int) */
     for (read_counter = 0; read_counter < n_reads; read_counter++)
     {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Minor fix to the basic app that adds a delay to reading the accelerometer data after configuring the sensor.
Closes #224 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add a minor delay to the basic app, so that the sensor can retrieve relevant data after configuring the system

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

...

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

...
